### PR TITLE
Fix warning with Xcode 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,19 @@
 // swift-tools-version:5.1
 import PackageDescription
 
+var platform: SupportedPlatform {
+    #if compiler(<5.3)
+        return .iOS(.v8)
+    #else
+        // Xcode 12 (which ships with Swift 5.3) drops support for iOS 8
+        return .iOS(.v9)
+    #endif
+}
+
 let package = Package(
     name: "TURecipientBar",
     platforms: [
-        .iOS(.v8),
+        platform,
     ],
     products: [
         .library(


### PR DESCRIPTION
When using Xcode 12, there is a warning `The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.2.99.`. In order to get rid of that warning, the deployment target was bumped to iOS 9, but to maintain support for older versions of Xcode with a lower deployment target, the previous package is also included for older versions of Swift.